### PR TITLE
Fix code scanning alert no. 2: Missing CSRF middleware

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -38,7 +38,8 @@
     "ts-node": "^10.9.1",
     "typescript": "^4.9.4",
     "uuid": "^9.0.0",
-    "yarn": "^1.22.22"
+    "yarn": "^1.22.22",
+    "lusca": "^1.7.0"
   },
   "devDependencies": {
     "@types/bcrypt": "^5.0.2",

--- a/app/src/middlewares/session.ts
+++ b/app/src/middlewares/session.ts
@@ -1,8 +1,12 @@
 import session from 'express-session';
+import lusca from 'lusca';
 
-export const sessionMiddleware = session({
-    secret: 'change-me-secret-key',
-    resave: false,
-    saveUninitialized: false,
-    cookie: { secure: false } 
-});
+export const sessionMiddleware = [
+    session({
+        secret: 'change-me-secret-key',
+        resave: false,
+        saveUninitialized: false,
+        cookie: { secure: false } 
+    }),
+    lusca.csrf()
+];


### PR DESCRIPTION
Fixes [https://github.com/privlol/Search/security/code-scanning/2](https://github.com/privlol/Search/security/code-scanning/2)

To fix the problem, we need to add CSRF protection middleware to the Express application. The best way to do this is by using a well-known middleware package such as `lusca`. This package provides easy-to-use CSRF protection that can be integrated into the existing middleware stack.

1. Install the `lusca` package.
2. Import the `lusca` package in the `app/src/middlewares/session.ts` file.
3. Add the CSRF protection middleware to the existing middleware stack.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
